### PR TITLE
Change work in Description section

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
         <!-- End of Description -->
         <!-- Subscribe link -->
         <div class="text-uppercase" id="subscribe">
-          <a href=" https://medium.com/higher-learning" target="_blank">Check Out the Blog</a>
+          <a href=" https://medium.com/higher-learning/tagged/resources" target="_blank">Get Online Resources</a>
           <br> <br>
           <a id="open-popup" onclick="showMailingPopUp(); return false;">subscribe to the Newsletter</a>
         </div>


### PR DESCRIPTION
Fixed the name of the URL of the first link in 'Description'. 
Also fixed the path of the link. 